### PR TITLE
EVG-13121: add option to force service to run interactively

### DIFF
--- a/service.go
+++ b/service.go
@@ -124,6 +124,10 @@ type Config struct {
 	//     the generated service config file, will not check their correctness.
 	Dependencies []string
 
+	// Force the service to run interactively, even if it's running under the
+	// system service manager.
+	ForceInteractive bool
+
 	// The following fields are not supported on Windows.
 	WorkingDirectory string // Initial working directory.
 	ChRoot           string
@@ -367,8 +371,12 @@ type Service interface {
 	String() string
 
 	// Platform displays the name of the system that manages the service.
-	// In most cases this will be the same as service.Platform().
+	// In most cases, this will be the same as service.Platform().
 	Platform() string
+
+	// Interactive returns whether or not the service is running interactively
+	// or not. In most cases, this will be the same as service.Interactive().
+	Interactive() bool
 
 	// Status returns the current service status.
 	Status() (Status, error)

--- a/service_darwin.go
+++ b/service_darwin.go
@@ -27,12 +27,15 @@ type darwinSystem struct{}
 func (darwinSystem) String() string {
 	return version
 }
+
 func (darwinSystem) Detect() bool {
 	return true
 }
+
 func (darwinSystem) Interactive() bool {
 	return interactive
 }
+
 func (darwinSystem) New(i Interface, c *Config) (Service, error) {
 	s := &darwinLaunchdService{
 		i:      i,
@@ -79,6 +82,13 @@ func (s *darwinLaunchdService) String() string {
 
 func (s *darwinLaunchdService) Platform() string {
 	return version
+}
+
+func (s *darwinLaunchdService) Interactive() bool {
+	if s.Config.ForceInteractive {
+		return true
+	}
+	return system.Interactive()
 }
 
 func (s *darwinLaunchdService) getHomeDir() (string, error) {
@@ -216,6 +226,7 @@ func (s *darwinLaunchdService) Start() error {
 	}
 	return run("launchctl", "load", confPath)
 }
+
 func (s *darwinLaunchdService) Stop() error {
 	confPath, err := s.getServiceFilePath()
 	if err != nil {
@@ -223,6 +234,7 @@ func (s *darwinLaunchdService) Stop() error {
 	}
 	return run("launchctl", "unload", confPath)
 }
+
 func (s *darwinLaunchdService) Restart() error {
 	err := s.Stop()
 	if err != nil {
@@ -250,7 +262,7 @@ func (s *darwinLaunchdService) Run() error {
 }
 
 func (s *darwinLaunchdService) Logger(errs chan<- error) (Logger, error) {
-	if interactive {
+	if s.Interactive() {
 		return ConsoleLogger, nil
 	}
 	return s.SystemLogger(errs)

--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -66,6 +66,13 @@ func (s *systemd) Platform() string {
 	return s.platform
 }
 
+func (s *systemd) Interactive() bool {
+	if s.Config.ForceInteractive {
+		return true
+	}
+	return system.Interactive()
+}
+
 // Systemd services should be supported, but are not currently.
 var errNoUserServiceSystemd = errors.New("User services are not supported on systemd.")
 
@@ -191,7 +198,7 @@ func (s *systemd) Uninstall() error {
 }
 
 func (s *systemd) Logger(errs chan<- error) (Logger, error) {
-	if system.Interactive() {
+	if s.Interactive() {
 		return ConsoleLogger, nil
 	}
 	return s.SystemLogger(errs)

--- a/service_sysv_linux.go
+++ b/service_sysv_linux.go
@@ -42,6 +42,13 @@ func (s *sysv) Platform() string {
 	return s.platform
 }
 
+func (s *sysv) Interactive() bool {
+	if s.Config.ForceInteractive {
+		return true
+	}
+	return system.Interactive()
+}
+
 var errNoUserServiceSystemV = errors.New("User services are not supported on SystemV.")
 
 func (s *sysv) configPath() (cp string, err error) {
@@ -126,7 +133,7 @@ func (s *sysv) Uninstall() error {
 }
 
 func (s *sysv) Logger(errs chan<- error) (Logger, error) {
-	if system.Interactive() {
+	if s.Interactive() {
 		return ConsoleLogger, nil
 	}
 	return s.SystemLogger(errs)

--- a/service_upstart_linux.go
+++ b/service_upstart_linux.go
@@ -57,6 +57,13 @@ func (s *upstart) Platform() string {
 	return s.platform
 }
 
+func (s *upstart) Interactive() bool {
+	if s.Config.ForceInteractive {
+		return true
+	}
+	return system.Interactive()
+}
+
 // Upstart has some support for user services in graphical sessions.
 // Due to the mix of actual support for user services over versions, just don't bother.
 // Upstart will be replaced by systemd in most cases anyway.
@@ -176,7 +183,7 @@ func (s *upstart) Uninstall() error {
 }
 
 func (s *upstart) Logger(errs chan<- error) (Logger, error) {
-	if system.Interactive() {
+	if s.Interactive() {
 		return ConsoleLogger, nil
 	}
 	return s.SystemLogger(errs)

--- a/service_windows.go
+++ b/service_windows.go
@@ -149,6 +149,13 @@ func (ws *windowsService) Platform() string {
 	return version
 }
 
+func (ws *windowsService) Interactive() bool {
+	if ws.Config.ForceInteractive {
+		return true
+	}
+	return system.Interactive()
+}
+
 func (ws *windowsService) setError(err error) {
 	ws.errSync.Lock()
 	defer ws.errSync.Unlock()
@@ -253,7 +260,7 @@ func (ws *windowsService) Uninstall() error {
 
 func (ws *windowsService) Run() error {
 	ws.setError(nil)
-	if !interactive {
+	if !ws.Interactive() {
 		// Return error messages from start and stop routines
 		// that get executed in the Execute method.
 		// Guarded with a mutex as it may run a different thread
@@ -422,7 +429,7 @@ func getStopTimeout() time.Duration {
 }
 
 func (ws *windowsService) Logger(errs chan<- error) (Logger, error) {
-	if interactive {
+	if ws.Interactive() {
 		return ConsoleLogger, nil
 	}
 	return ws.SystemLogger(errs)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13121


The service chooses how to run depending on whether the process that starts the service is interactive. If the process is interactive, the OS will attempt to run it without relying on the system service manager (e.g. systemd, Windows service manager). However, if it's non-interactive, it tries to use the system service manager to run the existing service.

In the Windows hosts, Windows considers neither the cygwin shell nor the Evergreen agent an interactive process. because those processes do not have [the correct SID indicating an interactive process](https://stackoverflow.com/questions/2668851/how-do-i-detect-that-my-application-is-running-as-service-or-in-an-interactive-s). This change adds a field that forces the service to run as if in an interactive session, even the process that started it is considered non-interactive.