### PR TITLE
EVG-13293: support MacOS resource limits

### DIFF
--- a/service_darwin.go
+++ b/service_darwin.go
@@ -279,36 +279,32 @@ var launchdConfig = `<?xml version='1.0' encoding='UTF-8'?>
 <key>Label</key><string>{{html .Name}}</string>
 <key>ProgramArguments</key>
 <array>
-        <string>{{html .Path}}</string>
-{{range .Config.Arguments}}
-        <string>{{html .}}</string>
-{{end}}
-</array>
-{{if .UserName}}<key>UserName</key><string>{{html .UserName}}</string>{{end}}
-{{if .ChRoot}}<key>RootDirectory</key><string>{{html .ChRoot}}</string>{{end}}
-{{if .WorkingDirectory}}<key>WorkingDirectory</key><string>{{html .WorkingDirectory}}</string>{{end}}
-{{if .Environment}}<key>EnvironmentVariables</key>
+	<string>{{html .Path}}</string>
+{{range .Config.Arguments}}	<string>{{html .}}</string>
+{{end}}</array>
+{{if .UserName}}<key>UserName</key><string>{{html .UserName}}</string>
+{{end}}{{if .ChRoot}}<key>RootDirectory</key><string>{{html .ChRoot}}</string>
+{{end}}{{if .WorkingDirectory}}<key>WorkingDirectory</key><string>{{html .WorkingDirectory}}</string>
+{{end}}{{if .Environment}}<key>EnvironmentVariables</key>
 <dict>
 {{range $name, $value := .Environment}}<key>{{$name}}</key>
 <string>{{$value}}</string>
 {{end}}</dict>
-{{end}}
-{{if .ProcessType}}<key>ProcessType</key><string>{{html .ProcessType}}</string>{{end}}
-{{if or .Option.LimitLockedMemory .Option.LimitNumFiles .Option.LimitNumProcs .Option.LimitVirtualMemory}}
+{{end}}{{if .ProcessType}}<key>ProcessType</key><string>{{html .ProcessType}}</string>
+{{end}}{{if or .Option.LimitLockedMemory .Option.LimitNumFiles .Option.LimitNumProcs .Option.LimitVirtualMemory}}
 <key>HardResourceLimits</key>
-<dict>
-{{if .Options.LimitLockedMemory}}<string>MemoryLock</string><integer>{{.Options.LimitLockedMemory}}</integer>
-{{end}}{{if .Options.LimitNumFiles}}<string>NumberOfFiles</string><integer>{{.Options.LimitNumFiles}}</integer>
-{{end}}{{if .Options.LimitNumProcs}}<string>NumberOfProcesses</string><integer>{{.Options.LimitNumProcs}}</integer>
-{{end}}</dict>
+	<dict>
+	{{if .Option.LimitLockedMemory}}	<key>MemoryLock</key><integer>{{.Option.LimitLockedMemory}}</integer>
+	{{end}}{{if .Option.LimitNumFiles}}	<key>NumberOfFiles</key><integer>{{.Option.LimitNumFiles}}</integer>
+	{{end}}{{if .Option.LimitNumProcs}}	<key>NumberOfProcesses</key><integer>{{.Option.LimitNumProcs}}</integer>
+	{{end}}</dict>
 <key>SoftResourceLimits</key>
-<dict>
-{{if .Options.LimitLockedMemory}}<string>MemoryLock</string><integer>{{.Options.LimitLockedMemory}}</integer>
-{{end}}{{if .Options.LimitNumFiles}}<string>NumberOfFiles</string><integer>{{.Options.LimitNumFiles}}</integer>
-{{end}}{{if .Options.LimitNumProcs}}<string>NumberOfProcesses</string><integer>{{.Options.LimitNumProcs}}</integer>
-{{end}}</dict>
-{{end}}
-<key>SessionCreate</key><{{bool .SessionCreate}}/>
+	<dict>
+	{{if .Option.LimitLockedMemory}}	<key>MemoryLock</key><integer>{{.Option.LimitLockedMemory}}</integer>
+	{{end}}{{if .Option.LimitNumFiles}}	<key>NumberOfFiles</key><integer>{{.Option.LimitNumFiles}}</integer>
+	{{end}}{{if .Option.LimitNumProcs}}	<key>NumberOfProcesses</key><integer>{{.Option.LimitNumProcs}}</integer>
+	{{end}}</dict>
+{{end}}<key>SessionCreate</key><{{bool .SessionCreate}}/>
 <key>KeepAlive</key><{{bool .KeepAlive}}/>
 <key>RunAtLoad</key><{{bool .RunAtLoad}}/>
 <key>Disabled</key><false/>

--- a/service_darwin.go
+++ b/service_darwin.go
@@ -294,6 +294,20 @@ var launchdConfig = `<?xml version='1.0' encoding='UTF-8'?>
 {{end}}</dict>
 {{end}}
 {{if .ProcessType}}<key>ProcessType</key><string>{{html .ProcessType}}</string>{{end}}
+{{if or .Option.LimitLockedMemory .Option.LimitNumFiles .Option.LimitNumProcs .Option.LimitVirtualMemory}}
+<key>HardResourceLimits</key>
+<dict>
+{{if .Options.LimitLockedMemory}}<string>MemoryLock</string><integer>{{.Options.LimitLockedMemory}}</integer>
+{{end}}{{if .Options.LimitNumFiles}}<string>NumberOfFiles</string><integer>{{.Options.LimitNumFiles}}</integer>
+{{end}}{{if .Options.LimitNumProcs}}<string>NumberOfProcesses</string><integer>{{.Options.LimitNumProcs}}</integer>
+{{end}}</dict>
+<key>SoftResourceLimits</key>
+<dict>
+{{if .Options.LimitLockedMemory}}<string>MemoryLock</string><integer>{{.Options.LimitLockedMemory}}</integer>
+{{end}}{{if .Options.LimitNumFiles}}<string>NumberOfFiles</string><integer>{{.Options.LimitNumFiles}}</integer>
+{{end}}{{if .Options.LimitNumProcs}}<string>NumberOfProcesses</string><integer>{{.Options.LimitNumProcs}}</integer>
+{{end}}</dict>
+{{end}}
 <key>SessionCreate</key><{{bool .SessionCreate}}/>
 <key>KeepAlive</key><{{bool .KeepAlive}}/>
 <key>RunAtLoad</key><{{bool .RunAtLoad}}/>


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13293

Set hard/soft resource limits by specifying those fields in the service plist file ([docs](https://www.real-world-systems.com/docs/launchdPlist.1.html)).