### PR TITLE
EVG-13425: always use absolute path to initctl for upstart

### DIFF
--- a/service_upstart_linux.go
+++ b/service_upstart_linux.go
@@ -208,7 +208,7 @@ func (s *upstart) Run() (err error) {
 }
 
 func (s *upstart) Status() (Status, error) {
-	exitCode, out, err := runWithOutput("initctl", "status", s.Name)
+	exitCode, out, err := runWithOutput("/sbin/initctl", "status", s.Name)
 	if exitCode == 0 && err != nil {
 		return StatusUnknown, err
 	}
@@ -224,11 +224,11 @@ func (s *upstart) Status() (Status, error) {
 }
 
 func (s *upstart) Start() error {
-	return run("initctl", "start", s.Name)
+	return run("/sbin/initctl", "start", s.Name)
 }
 
 func (s *upstart) Stop() error {
-	return run("initctl", "stop", s.Name)
+	return run("/sbin/initctl", "stop", s.Name)
 }
 
 func (s *upstart) Restart() error {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13425

The init system that a Linux distro uses is detected by checking the version from `/sbin/initctl` and then, it installs the service assuming  that `/sbin` must be in the `PATH`.  However, on some Linux hosts, sshd is compiled with a different `PATH` from that one used in an interactive shell. If you run a command in an interactive shell, it first executes `/etc/profile`, which is a script to include `/sbin` in the `PATH`. Therefore, `/sbin` is not guaranteed to be included in the `PATH` unless you're running with an interactive shell. This is problematic when running `initctl` within SSH commands because if you run an SSH command without an interactive  shell (e.g. `ssh user@host initctl` just runs the command without using interactive shell session), it won't be able to find `/sbin/initctl`. I modified the service to always use the absolute path to `initctl`.